### PR TITLE
Only import FoundationNetworking in case necessary

### DIFF
--- a/swift-test-project/Sources/app/main.swift
+++ b/swift-test-project/Sources/app/main.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
 
 class HttpJsonApiClient {
   func post(url urlString: String, json: [String: String]) -> Any {


### PR DESCRIPTION
Since `FoundationNetworking` doesn't exist on Apple platform, it should be conditional import to improve compatibility.