### PR TITLE
Avoid crash when server is not running

### DIFF
--- a/swift-test-project/Sources/app/main.swift
+++ b/swift-test-project/Sources/app/main.swift
@@ -40,13 +40,10 @@ func renderBar(org: BarComponent_Org) {
 }
 
 let client = HttpJsonApiClient()
-if case .success(let result?) = client.post(
-    url: "http://localhost:4000/graphql",
-    json: [
-      "query": AppQuery.operationDefinition
-    ]
-  ) {
-  let result = AppQuery(json: result)
+let result = client.post(url: "http://localhost:4000/graphql", json: ["query": AppQuery.operationDefinition])
+switch result {
+case .success(let json?):
+  let result = AppQuery(json: json)
   print(result.data as Any)
   print(result.errors as Any)
   if let data = result.data {
@@ -58,4 +55,12 @@ if case .success(let result?) = client.post(
       print(org as Any)
     }
   }
+case .failure(let error):
+  print("""
+        [Error] \(error.localizedDescription)
+        To run the server, see README:
+        https://github.com/mtsmfm/graphql-codegen-swift-operations/tree/master/swift-test-project
+        """)
+default:
+  print("Unexpected response. The response was not JSON object.")
 }

--- a/swift-test-project/Sources/app/main.swift
+++ b/swift-test-project/Sources/app/main.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 class HttpJsonApiClient {
-  func post(url urlString: String, json: [String: String]) -> Any {
+  func post(url urlString: String, json: [String: String]) -> Result<[String: Any]?, Error> {
     let url = URL(string: urlString)!
     let session = URLSession.shared
     var request = URLRequest(url: url)
@@ -12,19 +12,22 @@ class HttpJsonApiClient {
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     let jsonData = try! JSONSerialization.data(withJSONObject: json, options: [])
     let sem = DispatchSemaphore.init(value: 0)
-    var result: Any? = nil
+    var result: Result<[String: Any]?, Error>!
     let task = session.uploadTask(with: request, from: jsonData) { data, response, error in
       defer { sem.signal() }
 
-      if let data = data, let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-        result = json
+      result = Result {
+        if let error = error {
+            throw error
+        }
+        return try data.flatMap{ try JSONSerialization.jsonObject(with: $0) as? [String: Any] }
       }
     }
 
     task.resume()
     sem.wait()
 
-    return result!
+    return result
   }
 }
 
@@ -37,12 +40,12 @@ func renderBar(org: BarComponent_Org) {
 }
 
 let client = HttpJsonApiClient()
-if let result = client.post(
+if case .success(let result?) = client.post(
     url: "http://localhost:4000/graphql",
     json: [
       "query": AppQuery.operationDefinition
     ]
-  ) as? [String: Any] {
+  ) {
   let result = AppQuery(json: result)
   print(result.data as Any)
   print(result.errors as Any)


### PR DESCRIPTION
## Problem

When the server is not running, it throws fatal exception.

```
$ swift run
Fatal error: Unexpectedly found nil while unwrapping an Optional value: file /path/to/graphql-codegen-swift-operations/swift-test-project/Sources/app/main.swift, line 25
Illegal instruction: 4
```

## Solution

Use `Result` to handle errors properly.